### PR TITLE
Add Expo React Native app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+package-lock.json
+node_modules/
+expo-app/node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
-# MER
+# Cat Food Calculator
+
+This repository contains a simple calculator for determining a cat's maintenance energy requirements (MER). The
+original version is a static HTML page backed by a small Node test suite. A React Native version built with the
+Expo framework is also included in the `expo-app` directory.
+
+## Running the Web Version
+
+Open `index.html` in a browser. The JavaScript logic lives in `calculator.js` and is tested with Jest.
+Run the tests with:
+
+```bash
+npm test
+```
+
+## Running the React Native Version
+
+The React Native app shares the same calculation logic and persists the entered values. Data is stored in the app's
+document directory which is backed up to iCloud on iOS and by the auto backup system on Android.
+
+Navigate to the `expo-app` folder and start Expo:
+
+```bash
+cd expo-app
+npx expo start
+```
+
+This requires the Expo CLI and dependencies installed locally.

--- a/expo-app/App.js
+++ b/expo-app/App.js
@@ -1,0 +1,80 @@
+import React, { useState, useEffect } from 'react';
+import { View, Text, TextInput, Button, StyleSheet } from 'react-native';
+import * as FileSystem from 'expo-file-system';
+import { calculateMER } from '../calculator';
+
+const DATA_FILE = FileSystem.documentDirectory + 'catData.json';
+
+export default function App() {
+    const [weight, setWeight] = useState('');
+    const [birthDate, setBirthDate] = useState('');
+    const [neutered, setNeutered] = useState('yes');
+    const [result, setResult] = useState(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const data = await FileSystem.readAsStringAsync(DATA_FILE);
+                const { w, b, n } = JSON.parse(data);
+                setWeight(w);
+                setBirthDate(b);
+                setNeutered(n);
+            } catch (e) {
+                // File may not exist on first run
+            }
+        })();
+    }, []);
+
+    const handleCalculate = async () => {
+        const mer = calculateMER(weight, birthDate, neutered);
+        setResult(mer);
+        const data = JSON.stringify({ w: weight, b: birthDate, n: neutered });
+        await FileSystem.writeAsStringAsync(DATA_FILE, data);
+    };
+
+    return (
+        <View style={styles.container}>
+            <Text>Weight (kg)</Text>
+            <TextInput
+                style={styles.input}
+                value={weight}
+                onChangeText={setWeight}
+                keyboardType="numeric"
+            />
+            <Text>Birth Date (YYYY-MM-DD)</Text>
+            <TextInput
+                style={styles.input}
+                value={birthDate}
+                onChangeText={setBirthDate}
+            />
+            <Text>Neutered? (yes/no)</Text>
+            <TextInput
+                style={styles.input}
+                value={neutered}
+                onChangeText={setNeutered}
+            />
+            <Button title="Calculate" onPress={handleCalculate} />
+            {result !== null && (
+                <Text style={styles.result}>MER: {result}</Text>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 20,
+        justifyContent: 'center'
+    },
+    input: {
+        borderWidth: 1,
+        borderColor: '#ccc',
+        marginBottom: 10,
+        padding: 8
+    },
+    result: {
+        fontSize: 18,
+        marginTop: 10
+    }
+});

--- a/expo-app/app.json
+++ b/expo-app/app.json
@@ -1,0 +1,16 @@
+{
+    "expo": {
+        "name": "CatFoodCalculator",
+        "slug": "cat-food-calculator",
+        "version": "1.0.0",
+        "platforms": ["ios", "android"],
+        "jsEngine": "hermes",
+        "android": {
+            "package": "com.example.catfoodcalculator",
+            "allowBackup": true
+        },
+        "ios": {
+            "bundleIdentifier": "com.example.catfoodcalculator"
+        }
+    }
+}

--- a/expo-app/babel.config.js
+++ b/expo-app/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+    api.cache(true);
+    return {
+        presets: ['babel-preset-expo']
+    };
+};

--- a/expo-app/package.json
+++ b/expo-app/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "cat-food-calculator-expo",
+    "version": "1.0.0",
+    "main": "App.js",
+    "private": true,
+    "dependencies": {
+        "expo": "^49.0.0",
+        "react": "18.2.0",
+        "react-native": "0.72.4",
+        "expo-file-system": "~15.2.2"
+    }
+}


### PR DESCRIPTION
## Summary
- build React Native version in `expo-app`
- persist form entries with `expo-file-system` for automatic iCloud/Android backup
- document how to run both the web and mobile versions
- ignore dependency directories and lockfiles

## Testing
- `npm test`